### PR TITLE
Fix cf-node-version image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ In addition, ESLint 9 [requires Node.js >= 18.18.0](https://eslint.org/blog/2024
 
 - `Settings` > `Environment variables`
 
-      >![](.images/cf-node-version.png)
-      
+>![](.images/cf-node-version.png)
+
    - and same for `Preview`
 
 Now, your pages get deployed to an URL like `https://lab-4hl.pages.dev` at each new push to `main` (where the build succeeds).


### PR DESCRIPTION
Small change to get image to show in README on github page render... small markdown edit basically